### PR TITLE
Pin GitHub Actions to latest releases with commit SHAs

### DIFF
--- a/.github/workflows/main-deploy-production.yml
+++ b/.github/workflows/main-deploy-production.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install doctl
         uses: digitalocean/action-doctl@135ac0aa0eed4437d547c6f12c364d3006b42824 # v2.5.1
         with:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,6 +6,6 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: rojopolis/spellcheck-github-actions@0.58.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: rojopolis/spellcheck-github-actions@0bf4b2f91efa259b52c202b09b0c3845c524ff36 # 0.58.0
       name: Spellcheck


### PR DESCRIPTION
This PR pins all GitHub Actions to their latest releases using commit SHAs for enhanced security, with human-readable version comments for maintainability.

## Changes

- **actions/checkout**: Updated from v6.0.0 to v6.0.1 and pinned to SHA with version comment
- **rojopolis/spellcheck-github-actions**: Pinned to SHA with version comment (already at latest 0.58.0)
- **digitalocean/action-doctl**: Already pinned correctly at v2.5.1 (latest)

## Benefits

- ✅ Enhanced security by using commit SHAs instead of mutable tags
- ✅ Version comments maintain readability for humans
- ✅ Dependabot can automatically update pinned actions
- ✅ All actions are at their latest stable releases

## Testing

The workflows should continue to function as before, with improved security posture.